### PR TITLE
Add LINE URL scheme to UriAction

### DIFF
--- a/src/LineBot/Actions/UriAction.cs
+++ b/src/LineBot/Actions/UriAction.cs
@@ -57,7 +57,7 @@ namespace Line
 
         /// <summary>
         /// Gets or sets the url opened when the action is performed.
-        /// <para>Protocol: HTTP, HTTPS, TEL.</para>
+        /// <para>Protocol: HTTP, HTTPS, LINE, TEL.</para>
         /// <para>Max url length: 1000 characters.</para>
         /// </summary>
         [JsonProperty("uri")]
@@ -75,8 +75,9 @@ namespace Line
 
                 if (!"http".Equals(value.Scheme, StringComparison.OrdinalIgnoreCase) &&
                     !"https".Equals(value.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                    !"line".Equals(value.Scheme, StringComparison.OrdinalIgnoreCase) &&
                     !"tel".Equals(value.Scheme, StringComparison.OrdinalIgnoreCase))
-                    throw new InvalidOperationException("The url should use the http, https or tel scheme.");
+                    throw new InvalidOperationException("The url should use the http, https, line or tel scheme.");
 
                 if (value.ToString().Length > 1000)
                     throw new InvalidOperationException("The url cannot be longer than 1000 characters.");

--- a/tests/LineBot.Tests/Actions/UriActionTests/TheUrlProperty.cs
+++ b/tests/LineBot.Tests/Actions/UriActionTests/TheUrlProperty.cs
@@ -34,11 +34,11 @@ namespace Line.Tests
             }
 
             [TestMethod]
-            public void ShouldThrowExceptionWhenValueIsNotHttpOrHttpsOrTel()
+            public void ShouldThrowExceptionWhenValueIsNotHttpOrHttpsOrLineOrTel()
             {
                 var action = new UriAction();
 
-                ExceptionAssert.Throws<InvalidOperationException>("The url should use the http, https or tel scheme.", () =>
+                ExceptionAssert.Throws<InvalidOperationException>("The url should use the http, https, line or tel scheme.", () =>
                 {
                     action.Url = new Uri("ftp://foo.bar");
                 });
@@ -59,6 +59,15 @@ namespace Line.Tests
                 var action = new UriAction
                 {
                     Url = new Uri("https://foo.bar")
+                };
+            }
+
+            [TestMethod]
+            public void ShouldNotThrowExceptionWhenValueIsLine()
+            {
+                var action = new UriAction
+                {
+                    Url = new Uri("line://nv/camera/")
                 };
             }
 


### PR DESCRIPTION
According to https://developers.line.biz/en/reference/messaging-api/#uri-action, now support LINE URL scheme.

I am using this for send LIFF link.